### PR TITLE
Protection From Evil is both a Priest and Wizard spell.

### DIFF
--- a/src/lib/compendium/spellCompendium.ts
+++ b/src/lib/compendium/spellCompendium.ts
@@ -356,7 +356,7 @@ export const SPELLS: SpellInfo[] = [
   {
     name: "Protection From Evil",
     range: "Close",
-    class: "Priest",
+    class: "PriestWizard",
     tier: 1,
     desc: "For the spell’s duration, chaotic beings have disadvantage on attack rolls and hostile spellcasting checks against the target. These beings also can’t possess, compel, or beguile it.When cast on an already-possessed target, the possessing entity makes a CHA check vs. the last spellcasting check. On a failure, the entity is expelled.",
     duration: { type: "Focus", amt: 0 },


### PR DESCRIPTION
Player quickstart guide p.64, main rules p.68