### PR TITLE
Add support to Luck Tokens

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -199,6 +199,16 @@
           </div>
         </div>
         <div class="col-span-full cell">
+          <label>
+            <h2>LUCK TOKENS</h2>
+            <input
+              type="number"
+              inputmode="numeric"
+              bind:value={$pc.luckTokens}
+            />
+          </label>
+        </div>
+        <div class="col-span-full cell">
           <h2>TITLE</h2>
           {#if $pc.hasCustomClass}
             <input

--- a/src/lib/model/PlayerCharacter.ts
+++ b/src/lib/model/PlayerCharacter.ts
@@ -61,6 +61,7 @@ export function defaultPC(): PlayerCharacter {
     spells: [],
     customSpells: [],
     hitPoints: 1,
+    luckTokens: 1,
   };
 }
 

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -119,6 +119,7 @@ export type PlayerCharacter = {
   spells: Spell[];
   customSpells: SpellInfo[];
   hitPoints: number;
+  luckTokens: number;
 };
 
 /////// Bonus


### PR DESCRIPTION
# Add Support to Luck Tokens

This is a simple implementation of a Luck Token counting that support more than one Luck Tokens per character. I'm not fluent in svelt so if something here was wrong, just tell me that I'll change.

I didn't find a perfect spot to show the luck tokens field, so I put below the experience section.

Here's a screenshot of the suggestion

![SCR-20240906-ozwh](https://github.com/user-attachments/assets/eac15b7e-fa73-4338-8278-1e8b9f2a1531)

## Ideas to improve this feature

I was thinking that in the future we could add a max and min amount of luck tokens in the configuration section, and also have a toggle to disable it completely if it wasn't needed.
