### PR TITLE
[Fix] Clear "Import JSON" input value before importing

### DIFF
--- a/src/lib/components/OptionsButton.svelte
+++ b/src/lib/components/OptionsButton.svelte
@@ -67,6 +67,10 @@
         class="hidden"
         accept="application/json"
         bind:files
+        on:click={(e) => {
+          e.currentTarget.value = "";
+          files = undefined;
+        }}
       />
     </label>
     <button


### PR DESCRIPTION
Fixes #51 

Check the bug report #51 for details on the issue and how to reproduce.

The solution implemented here is pretty straightforward and is described in this Stack Overflow answer:
https://stackoverflow.com/a/74233411

This is needed to trigger the file change event in the file input when the user selects the same file to import again.