### PR TITLE
[Fix] Update tracked player if they leave the party

### DIFF
--- a/src/lib/services/OBRHelper.ts
+++ b/src/lib/services/OBRHelper.ts
@@ -82,6 +82,12 @@ async function initGM() {
       pmd[p.id] = p.metadata[pluginId("sheetData")];
     }
     PlayerMetaDataMapStore.set(pmd);
+
+    // update the tracked player if they leave the party
+    const trackedPlayer = get(TrackedPlayer);
+    if (!party.find((p) => p.id === trackedPlayer)) {
+      TrackedPlayer.set(OBR.player.id);
+    }
   });
 
   PlayerMetaDataMapStore.subscribe((pmd) => {


### PR DESCRIPTION
Fixes #57 

Show GM sheet when player currently tracked leaves the party.

### Demo

https://github.com/user-attachments/assets/99bd338e-73f2-4fc0-859d-fe52b16aa714

