### PR TITLE
[Feature]: track spellcasting failure

### DIFF
--- a/src/lib/components/HPView.svelte
+++ b/src/lib/components/HPView.svelte
@@ -15,6 +15,7 @@
   }
   function longRest() {
     $pc.hitPoints = $pc.maxHitPoints;
+    $pc.spells = $pc.spells.map((s) => ({ name: s.name, failed: false }));
   }
 </script>
 

--- a/src/lib/components/spells/SpellsView.svelte
+++ b/src/lib/components/spells/SpellsView.svelte
@@ -8,9 +8,27 @@
   import RollButton from "../RollButton.svelte";
   import SpellsButton from "./SpellsButton.svelte";
   import SpellInfoButton from "./SpellInfoButton.svelte";
+  import type { SpellInfo } from "../../types";
 
   $: spells = $pc.spells.map((s) => findSpell(s.name)).filter(Boolean);
   $: hasSpells = spells?.length > 0;
+
+  function toggleFailed(s: SpellInfo) {
+    const idx = $pc.spells.findIndex((spell) => spell.name === s.name);
+
+    if (idx === -1) {
+      $pc.spells.push({ name: s.name, failed: true });
+    } else {
+      $pc.spells[idx].failed = !$pc.spells[idx].failed;
+    }
+
+    $pc = $pc;
+  }
+
+  function hasFailedSpellcast(s: SpellInfo): boolean {
+    const idx = $pc.spells.findIndex((spell) => spell.name === s.name);
+    return idx !== -1 && $pc.spells[idx].failed;
+  }
 </script>
 
 <h2>Spells</h2>
@@ -24,7 +42,14 @@
             <div>{spell.name}</div>
             <SpellInfoButton {spell} />
           </div>
-          <div class="flex">
+          <div class="flex items-center gap-2">
+            <input
+              title="spellcasting failed"
+              type="checkbox"
+              class="w-6 h-6"
+              checked={hasFailedSpellcast(spell)}
+              on:click={() => toggleFailed(spell)}
+            />
             <RollButton modifier={mod} />
           </div>
         </div>

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -56,6 +56,7 @@ export type Talent = GenericTalent | BonusTalent | ChooseBonusTalent;
 export type SpellTier = 1 | 2 | 3 | 4 | 5;
 export type Spell = {
   name: string;
+  failed?: boolean; //  spellcasting check failed
 };
 export type SpellClass =
   | Extract<Class, "Wizard" | "Priest">


### PR DESCRIPTION
This PR adds the ability to track failed spellcasting, along with automatically restoring those spells on a long rest.

https://github.com/user-attachments/assets/a3c34283-3a33-43a5-ade6-65b82c7dffc4

Closes https://github.com/maxpaulus43/owlbear-shadowdark-character-sheet/issues/59