### PR TITLE
Update Sleep

### DIFF
--- a/src/lib/compendium/spellCompendium.ts
+++ b/src/lib/compendium/spellCompendium.ts
@@ -398,7 +398,7 @@ export const SPELLS: SpellInfo[] = [
     range: "Near",
     class: "Wizard",
     tier: 1,
-    desc: "This spell fills a near-sized cube extending from you. Choose a number of living creatures in the area up to your level. Those creatures fall into a deep sleep if they are LV 2 or less. Injury or vigorous shaking wakes them.",
+    desc: "You weave a lulling spell that fills a near-sized cube extending from you. Living creatures in the area of effect fall into a deep sleep if they are LV 2 or less. Vigorous shaking or being injured wakes them.",
     duration: { type: "Instant", amt: 0 },
   },
   {


### PR DESCRIPTION
Hi! Looks like you had an old version of Sleep in there, before the version that went to print. The targeting is different (limits on number of creatures, exempting your friends). Kelsey has clarified that here:

https://www.reddit.com/r/shadowdark/comments/1gx34km/spell_rules_sleep_and_mage_armor/

and here's the new wording, proposed in my change! Full credit to my wife whose gropu is using your extension and who took Sleep at 2nd level, noticed the discrepancy, and found your repo. I'm just the one with the github account. 

"You weave a lulling spell that fills a near-sized cube extending from you. Living creatures in the area of effect fall into a deep sleep if they are LV 2 or less. Vigorous shaking or being injured wakes them."